### PR TITLE
docs: Add privacy-safe support policy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ https://kriptofolio.app
 ![kriptofolio_phone_screenshots_combination_one-in-two](https://user-images.githubusercontent.com/2387056/66703930-3bd40d80-ed20-11e9-8603-a2379c1e6551.jpg)
 
 
+## Support
+
+See [SUPPORT.md](SUPPORT.md) for help, privacy-safe bug reports, and security reports.
+
+
 ## License
 
     Copyright 2018-2023 Andrius Baruckis www.baruckis.com | kriptofolio.app

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,37 @@
+# Kriptofolio Support
+
+## Get help
+
+For private support, email [hello@kriptofolio.app](mailto:hello@kriptofolio.app).
+
+For a reproducible bug that contains no private information, you may open a GitHub issue. Include:
+
+- the Kriptofolio app version;
+- the Android version and device model;
+- clear steps to reproduce the problem;
+- the expected and actual result;
+- a screenshot only after removing balances, holdings, addresses, notifications, and other
+  personal information.
+
+Support is provided on a best-effort basis. Please do not send the same request through several
+channels.
+
+## Protect your information
+
+Kriptofolio does not need your seed phrase, private key, exchange password, API key, recovery
+code, or complete portfolio to investigate a problem. Never send any of them.
+
+Portfolio data is stored locally on your Android device. Information that you voluntarily include
+in a support email is processed as email correspondence, so share only the minimum needed to
+explain the problem.
+
+## Security reports
+
+Do not publish a suspected vulnerability if it could put users at risk. Email
+[hello@kriptofolio.app](mailto:hello@kriptofolio.app) with `Security report` in the subject and a
+minimal reproduction that contains no real credentials or financial data.
+
+## Internal infrastructure
+
+This public repository intentionally does not document email routing, DNS administration,
+hosting accounts, backups, or private operational procedures.


### PR DESCRIPTION
## What changed

- added a public SUPPORT.md with safe bug-reporting guidance;
- explicitly tells users never to send seed phrases, private keys, exchange passwords, API keys, recovery codes, or a full portfolio;
- linked the policy from README.md;
- kept DNS, forwarding, mailbox, backup, and provider details out of the public repository.

## Validation

- staged secret scan passed;
- diff check passed;
- no application code or runtime behavior changed.

The private operational route remains in the separate private site repository. Merge remains a human decision.